### PR TITLE
Fix network URL policy matching

### DIFF
--- a/agent_guardrail/policy.py
+++ b/agent_guardrail/policy.py
@@ -36,6 +36,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,28 @@ def _matches_pattern(value: str, patterns: List[str]) -> bool:
         if fnmatch.fnmatch(value.lower(), pattern.lower()):
             return True
     return False
+
+
+def _network_match_values(target: str) -> List[str]:
+    """Return URL and host candidates for network policy matching."""
+    candidates = [target]
+    parsed = urlparse(target)
+
+    # Bare hosts like "api.example.com/path" parse as a path, not a host.
+    if not parsed.hostname and "://" not in target:
+        parsed = urlparse(f"//{target}")
+
+    if parsed.hostname:
+        candidates.append(parsed.hostname)
+        if parsed.netloc:
+            candidates.append(parsed.netloc)
+
+    return list(dict.fromkeys(candidates))
+
+
+def _matches_network_pattern(target: str, patterns: List[str]) -> bool:
+    """Check if a network target or its parsed host matches any policy pattern."""
+    return any(_matches_pattern(candidate, patterns) for candidate in _network_match_values(target))
 
 
 class PolicyEngine:
@@ -116,12 +139,15 @@ class PolicyEngine:
         if not agent.get("enabled"):
             return PolicyDecision(decision="deny", reason="Agent disabled")
 
-        # Normalize target to prevent path traversal bypass on denylists
+        # Normalize file-like targets to prevent path traversal bypass on denylists.
         if target:
-            target = os.path.normpath(target)
-            # normpath preserves leading // on POSIX (implementation-defined) — collapse it
-            if target.startswith("//") and not target.startswith("///"):
-                target = target[1:]
+            if action_type == "network_request":
+                target = target.strip()
+            else:
+                target = os.path.normpath(target).replace("\\", "/")
+                # normpath preserves leading // on POSIX (implementation-defined) — collapse it
+                if target.startswith("//") and not target.startswith("///"):
+                    target = target[1:]
 
         # Clamp cost to non-negative (prevent spend cap bypass via negative cost)
         cost_usd = max(0.0, cost_usd)
@@ -184,10 +210,10 @@ class PolicyEngine:
             # Network denylist
             network_deny = rules.get("network_denylist", [])
             if action_type == "network_request" and target and network_deny:
-                if _matches_pattern(target, network_deny):
+                if _matches_network_pattern(target, network_deny):
                     # Check allowlist override
                     network_allow = rules.get("network_allowlist", [])
-                    if not (network_allow and _matches_pattern(target, network_allow)):
+                    if not (network_allow and _matches_network_pattern(target, network_allow)):
                         return PolicyDecision(
                             decision="deny",
                             reason=f"Network target '{target}' denied",

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -323,6 +323,72 @@ class TestNetworkDenylist:
         decision = engine.evaluate(agent["id"], "network_request", target="api.openai.com")
         assert decision.decision == "allow"
 
+    def test_deny_network_url_by_hostname(self, store, agent, engine):
+        store.save_policy(
+            {
+                "name": "no-evil",
+                "agent_id": agent["id"],
+                "rules": {"network_denylist": ["evil.com"]},
+            }
+        )
+        decision = engine.evaluate(
+            agent["id"],
+            "network_request",
+            target="https://evil.com/api/v1",
+        )
+        assert decision.decision == "deny"
+
+    def test_deny_network_url_by_subdomain_pattern(self, store, agent, engine):
+        store.save_policy(
+            {
+                "name": "no-example-subdomains",
+                "agent_id": agent["id"],
+                "rules": {"network_denylist": ["*.example.com"]},
+            }
+        )
+        decision = engine.evaluate(
+            agent["id"],
+            "network_request",
+            target="https://api.example.com/v1/messages",
+        )
+        assert decision.decision == "deny"
+
+    def test_network_allowlist_override_full_url(self, store, agent, engine):
+        store.save_policy(
+            {
+                "name": "restricted-network",
+                "agent_id": agent["id"],
+                "rules": {
+                    "network_denylist": ["*"],
+                    "network_allowlist": ["api.openai.com"],
+                },
+            }
+        )
+        decision = engine.evaluate(
+            agent["id"],
+            "network_request",
+            target="https://api.openai.com/v1/chat/completions",
+        )
+        assert decision.decision == "allow"
+
+    def test_network_allowlist_override_case_and_port(self, store, agent, engine):
+        store.save_policy(
+            {
+                "name": "restricted-network",
+                "agent_id": agent["id"],
+                "rules": {
+                    "network_denylist": ["*"],
+                    "network_allowlist": ["api.openai.com"],
+                },
+            }
+        )
+        decision = engine.evaluate(
+            agent["id"],
+            "network_request",
+            target="HTTPS://API.OPENAI.COM:443/v1/chat/completions",
+        )
+        assert decision.decision == "allow"
+
 
 class TestEvaluateAndRecord:
     def test_evaluate_and_record_creates_action(self, store, agent, engine):


### PR DESCRIPTION
## Summary
- keep network_request targets as URLs instead of path-normalizing them
- match network allow/deny policies against parsed hostnames as well as the original target
- normalize file-like policy targets to forward slashes so sensitive path rules work consistently on Windows and POSIX
- add regression coverage for URL host matching, subdomain globs, allowlist overrides, and case/port handling

## Validation
- `python -m pytest tests/test_policy.py -q` -> 37 passed
- `PYTHONUTF8=1 python -m pytest -q` -> 106 passed
- `git diff --check` -> passed

Note: without UTF-8 mode, unrelated CLI tests fail on Windows when the CLI prints Unicode separator characters to a cp1252 console.